### PR TITLE
Add firmware unit test framework and sample tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Agent Instructions
+
+## Running Firmware Unit Tests
+
+Use the provided scripts to build and run the firmware unit tests.
+
+### Bash
+```bash
+./firmware/tests/run_tests.sh
+```
+
+### PowerShell
+```powershell
+pwsh ./firmware/tests/run_tests.ps1
+```

--- a/firmware/main/app/StateManager.cpp
+++ b/firmware/main/app/StateManager.cpp
@@ -1,0 +1,11 @@
+#include "StateManager.h"
+
+StateManager::StateManager() : state_(SystemState::Idle) {}
+
+void StateManager::setState(SystemState state) {
+    state_ = state;
+}
+
+SystemState StateManager::getState() const {
+    return state_;
+}

--- a/firmware/main/app/StateManager.h
+++ b/firmware/main/app/StateManager.h
@@ -1,0 +1,15 @@
+#pragma once
+
+enum class SystemState {
+    Idle,
+    Active
+};
+
+class StateManager {
+public:
+    StateManager();
+    void setState(SystemState state);
+    SystemState getState() const;
+private:
+    SystemState state_;
+};

--- a/firmware/main/hal/PowerHAL.cpp
+++ b/firmware/main/hal/PowerHAL.cpp
@@ -1,0 +1,20 @@
+#include "PowerHAL.h"
+
+PowerHAL::PowerHAL() : initialized_(false), low_power_mode_(false) {}
+
+int PowerHAL::init() {
+    initialized_ = true;
+    return 0; // success
+}
+
+bool PowerHAL::isInitialized() const {
+    return initialized_;
+}
+
+void PowerHAL::setLowPowerMode(bool enable) {
+    low_power_mode_ = enable;
+}
+
+bool PowerHAL::isLowPowerMode() const {
+    return low_power_mode_;
+}

--- a/firmware/main/hal/PowerHAL.h
+++ b/firmware/main/hal/PowerHAL.h
@@ -1,0 +1,13 @@
+#pragma once
+
+class PowerHAL {
+public:
+    PowerHAL();
+    int init();
+    bool isInitialized() const;
+    void setLowPowerMode(bool enable);
+    bool isLowPowerMode() const;
+private:
+    bool initialized_;
+    bool low_power_mode_;
+};

--- a/firmware/tests/CMakeLists.txt
+++ b/firmware/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.16)
+project(FirmwareTests)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+enable_testing()
+
+add_executable(run_tests
+    tests_main.cpp
+    test_power_hal.cpp
+    test_state_manager.cpp
+    ../main/hal/PowerHAL.cpp
+    ../main/app/StateManager.cpp
+)
+
+target_include_directories(run_tests PRIVATE ../main)
+
+add_test(NAME firmware_unit_tests COMMAND run_tests)

--- a/firmware/tests/minitest.h
+++ b/firmware/tests/minitest.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <vector>
+#include <string>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+
+struct TestRegistry {
+    std::vector<std::pair<std::string, std::function<void()>>> tests;
+    static TestRegistry& instance() {
+        static TestRegistry inst;
+        return inst;
+    }
+    void add(const std::string& name, std::function<void()> fn) {
+        tests.emplace_back(name, fn);
+    }
+};
+
+struct TestAdder {
+    TestAdder(const std::string& name, std::function<void()> fn) {
+        TestRegistry::instance().add(name, fn);
+    }
+};
+
+#define TEST(name) \
+void name(); \
+static TestAdder adder_##name(#name, name); \
+void name()
+
+#define EXPECT_EQ(a,b) \
+if(!((a) == (b))) { \
+    std::cerr << "EXPECT_EQ failed: " << #a << " != " << #b << std::endl; \
+    throw std::runtime_error("EXPECT_EQ failed"); \
+}
+
+#define EXPECT_TRUE(x) EXPECT_EQ(true, (x))
+#define EXPECT_FALSE(x) EXPECT_EQ(false, (x))

--- a/firmware/tests/run_tests.ps1
+++ b/firmware/tests/run_tests.ps1
@@ -1,0 +1,12 @@
+#!/usr/bin/env pwsh
+param()
+
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$BuildDir = Join-Path $ScriptDir "build"
+if (Test-Path $BuildDir) {
+    Remove-Item $BuildDir -Recurse -Force
+}
+cmake -S $ScriptDir -B $BuildDir
+cmake --build $BuildDir
+ctest --test-dir $BuildDir --output-on-failure

--- a/firmware/tests/run_tests.sh
+++ b/firmware/tests/run_tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="$SCRIPT_DIR/build"
+rm -rf "$BUILD_DIR"
+cmake -S "$SCRIPT_DIR" -B "$BUILD_DIR"
+cmake --build "$BUILD_DIR"
+ctest --test-dir "$BUILD_DIR" --output-on-failure

--- a/firmware/tests/test_power_hal.cpp
+++ b/firmware/tests/test_power_hal.cpp
@@ -1,0 +1,12 @@
+#include "minitest.h"
+#include "hal/PowerHAL.h"
+
+TEST(PowerHALInitializesAndSetsLowPower) {
+    PowerHAL hal;
+    EXPECT_FALSE(hal.isInitialized());
+    EXPECT_EQ(0, hal.init());
+    EXPECT_TRUE(hal.isInitialized());
+    EXPECT_FALSE(hal.isLowPowerMode());
+    hal.setLowPowerMode(true);
+    EXPECT_TRUE(hal.isLowPowerMode());
+}

--- a/firmware/tests/test_state_manager.cpp
+++ b/firmware/tests/test_state_manager.cpp
@@ -1,0 +1,9 @@
+#include "minitest.h"
+#include "app/StateManager.h"
+
+TEST(StateManagerStateTransitions) {
+    StateManager manager;
+    EXPECT_EQ(SystemState::Idle, manager.getState());
+    manager.setState(SystemState::Active);
+    EXPECT_EQ(SystemState::Active, manager.getState());
+}

--- a/firmware/tests/tests_main.cpp
+++ b/firmware/tests/tests_main.cpp
@@ -1,0 +1,16 @@
+#include "minitest.h"
+
+int main() {
+    int failed = 0;
+    for (const auto& t : TestRegistry::instance().tests) {
+        try {
+            t.second();
+            std::cout << "[PASS] " << t.first << std::endl;
+        } catch (const std::exception& e) {
+            std::cout << "[FAIL] " << t.first << ": " << e.what() << std::endl;
+            failed++;
+        }
+    }
+    std::cout << TestRegistry::instance().tests.size() - failed << "/" << TestRegistry::instance().tests.size() << " tests passed" << std::endl;
+    return failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Add minimal PowerHAL and StateManager modules for testing
- Introduce simple C++ test framework with sample tests
- Provide scripts and documentation to build and run tests

## Testing
- `./firmware/tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a90cbc97c08321ad82d742bb0cb442