### PR TITLE
Add ESP-IDF setup scripts and devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "SmartWatch DevContainer",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "runArgs": ["--device=/dev/ttyUSB0"],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "espressif.esp-idf-extension",
+        "ms-vscode.cpptools"
+      ]
+    }
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install base packages
+RUN apt-get update && apt-get install -y \
+    git curl wget python3 python3-pip xz-utils flex bison gperf \
+    libffi-dev libssl-dev dfu-util cmake ninja-build ccache \
+    libusb-1.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install PowerShell
+RUN wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    apt-get update && apt-get install -y powershell && \
+    rm packages-microsoft-prod.deb && rm -rf /var/lib/apt/lists/*
+
+# Install ESP-IDF
+ENV IDF_PATH=/opt/esp/esp-idf
+ENV IDF_TOOLS_PATH=/opt/esp/idf-tools
+RUN git clone --recursive https://github.com/espressif/esp-idf.git $IDF_PATH && \
+    bash $IDF_PATH/install.sh esp32s3 && \
+    echo ". $IDF_PATH/export.sh" >> /etc/profile.d/esp-idf.sh
+
+# Python requirements
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+WORKDIR /workspace
+SHELL ["/bin/bash", "-c"]

--- a/README.md
+++ b/README.md
@@ -72,31 +72,56 @@ SmartWatchProject/
    cd SmartWatchProject
    ```
 
-2. **Install Dependencies**
+2. **Run Setup Script**
+   ```bash
+   ./setup.sh
+   # or on Windows
+   powershell -ExecutionPolicy Bypass -File setup.ps1
+   ```
+   Installs PowerShell, ESP-IDF and Python packages.
+
+3. **Install Additional Dependencies**
    ```bash
    # For Arduino IDE
    # Install ESP32 board package and required libraries
-   
+
    # For ESP-IDF
    idf.py install
    ```
 
-3. **Build Firmware**
+4. **Build Firmware**
    ```bash
    # Arduino IDE: Open firmware/main/main.cpp and compile
-   
+
    # ESP-IDF
    cd firmware
    idf.py build
    ```
 
-4. **Flash Firmware**
+5. **Flash Firmware**
    ```bash
    # Arduino IDE: Use Upload button
-   
+
    # ESP-IDF
    idf.py flash monitor
    ```
+
+### Environment Variables
+
+After running `setup.sh` the following variables are useful:
+
+| Variable | Description |
+|----------|-------------|
+| `IDF_PATH` | Location of the ESP-IDF repository |
+| `IDF_TOOLS_PATH` | Directory containing ESP-IDF tools |
+
+Activate the ESP-IDF tools and update `PATH`:
+
+```bash
+export IDF_PATH=$HOME/esp/esp-idf
+export IDF_TOOLS_PATH=$HOME/esp/idf-tools
+source "$IDF_PATH/export.sh"
+```
 
 ## 🎨 ADHD-Friendly Design Principles
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyserial
+esptool

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,35 @@
+<#
+  Setup script for SmartWatchProject (Windows)
+  Installs PowerShell 7, ESP-IDF, and Python packages.
+#>
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-Command pwsh -ErrorAction SilentlyContinue)) {
+    Write-Host 'Installing PowerShell 7...'
+    winget install --id Microsoft.PowerShell --source winget -e
+}
+
+$espRoot = if ($env:ESP_ROOT) { $env:ESP_ROOT } else { Join-Path $env:USERPROFILE 'esp' }
+$env:IDF_PATH = if ($env:IDF_PATH) { $env:IDF_PATH } else { Join-Path $espRoot 'esp-idf' }
+$env:IDF_TOOLS_PATH = if ($env:IDF_TOOLS_PATH) { $env:IDF_TOOLS_PATH } else { Join-Path $espRoot 'idf-tools' }
+
+if (-not (Test-Path $env:IDF_PATH)) {
+    Write-Host "Cloning ESP-IDF into $env:IDF_PATH..."
+    git clone --recursive https://github.com/espressif/esp-idf.git $env:IDF_PATH
+}
+
+Write-Host 'Installing ESP-IDF tools...'
+& "$env:IDF_PATH/install.ps1" esp32s3
+
+if (Test-Path 'requirements.txt') {
+    Write-Host 'Installing Python packages...'
+    python -m pip install --upgrade pip
+    python -m pip install -r requirements.txt
+}
+
+Write-Host "`nInstallation complete."
+Write-Host 'To activate the ESP-IDF environment run:'
+Write-Host "  & `"$env:IDF_PATH/export.ps1`""
+Write-Host "`nEnvironment variables:"
+Write-Host "  setx IDF_PATH `"$env:IDF_PATH`""
+Write-Host "  setx IDF_TOOLS_PATH `"$env:IDF_TOOLS_PATH`""

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Setup script for SmartWatchProject
+# Installs PowerShell, ESP-IDF, and Python packages.
+
+ESP_ROOT="${ESP_ROOT:-$HOME/esp}"
+export IDF_PATH="${IDF_PATH:-$ESP_ROOT/esp-idf}"
+export IDF_TOOLS_PATH="${IDF_TOOLS_PATH:-$ESP_ROOT/idf-tools}"
+PYTHON="${PYTHON:-python3}"
+
+install_powershell() {
+  if ! command -v pwsh >/dev/null 2>&1; then
+    echo "Installing PowerShell..."
+    sudo apt-get update
+    sudo apt-get install -y wget apt-transport-https software-properties-common
+    wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+    sudo dpkg -i packages-microsoft-prod.deb
+    sudo apt-get update
+    sudo apt-get install -y powershell
+    rm packages-microsoft-prod.deb
+  else
+    echo "PowerShell already installed."
+  fi
+}
+
+install_esp_idf() {
+  if [ ! -d "$IDF_PATH" ]; then
+    echo "Cloning ESP-IDF into $IDF_PATH..."
+    mkdir -p "$(dirname "$IDF_PATH")"
+    git clone --recursive https://github.com/espressif/esp-idf.git "$IDF_PATH"
+  fi
+  echo "Installing ESP-IDF tools..."
+  bash "$IDF_PATH/install.sh" esp32s3
+}
+
+install_python_packages() {
+  if [ -f requirements.txt ]; then
+    echo "Installing Python packages..."
+    "$PYTHON" -m pip install --upgrade pip
+    "$PYTHON" -m pip install --no-cache-dir -r requirements.txt
+  fi
+}
+
+install_powershell
+install_esp_idf
+install_python_packages
+
+echo "\nInstallation complete."
+echo "To activate the ESP-IDF environment run:"
+echo "  source \"$IDF_PATH/export.sh\""
+echo "\nEnvironment variables:"
+echo "  export IDF_PATH=$IDF_PATH"
+echo "  export IDF_TOOLS_PATH=$IDF_TOOLS_PATH"


### PR DESCRIPTION
## Summary
- add setup scripts for Linux and Windows installing PowerShell, ESP-IDF and Python packages
- document IDF environment variables and call the setup script in README
- provide Dockerfile and devcontainer configuration preloaded with ESP-IDF

## Testing
- `bash -n setup.sh`
- `python -m json.tool .devcontainer/devcontainer.json`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(command not found)*
- `docker --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a90ca823748321a57c032ebc977c8f