### PR TITLE
Add firmware unit tests and runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS Instructions
+
+## Running Firmware Unit Tests
+
+To build and run the C++ unit tests for firmware modules:
+
+```bash
+./firmware/tests/run_tests.sh
+```
+
+On Windows PowerShell:
+
+```powershell
+./firmware/tests/run_tests.ps1
+```

--- a/firmware/tests/CMakeLists.txt
+++ b/firmware/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.14)
+project(FirmwareTests)
+
+add_executable(firmware_tests
+  PowerHAL.cpp
+  StateManager.cpp
+  test_powerhal.cpp
+  test_statemanager.cpp
+  test_main.cpp
+)

--- a/firmware/tests/PowerHAL.cpp
+++ b/firmware/tests/PowerHAL.cpp
@@ -1,0 +1,10 @@
+#include "PowerHAL.h"
+
+void PowerHAL::set_cpu_frequency(uint32_t freq_mhz) {
+    freq_mhz_ = freq_mhz;
+    profile_ = (freq_mhz_ > 160) ? PowerProfile::HIGH_PERFORMANCE : PowerProfile::NORMAL;
+}
+
+PowerProfile PowerHAL::get_current_profile() const {
+    return profile_;
+}

--- a/firmware/tests/PowerHAL.h
+++ b/firmware/tests/PowerHAL.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <cstdint>
+
+enum class PowerProfile {
+    NORMAL,
+    HIGH_PERFORMANCE
+};
+
+class PowerHAL {
+public:
+    PowerHAL() : freq_mhz_(160), profile_(PowerProfile::NORMAL) {}
+    void set_cpu_frequency(uint32_t freq_mhz);
+    PowerProfile get_current_profile() const;
+private:
+    uint32_t freq_mhz_;
+    PowerProfile profile_;
+};

--- a/firmware/tests/StateManager.cpp
+++ b/firmware/tests/StateManager.cpp
@@ -1,0 +1,19 @@
+#include "StateManager.h"
+
+void StateManager::start_focus_session(const std::string& task_id) {
+    state_ = AppState::FOCUS;
+    task_id_ = task_id;
+}
+
+void StateManager::end_focus_session() {
+    state_ = AppState::IDLE;
+    task_id_.clear();
+}
+
+AppState StateManager::get_current_state() const {
+    return state_;
+}
+
+std::string StateManager::current_task() const {
+    return task_id_;
+}

--- a/firmware/tests/StateManager.h
+++ b/firmware/tests/StateManager.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <string>
+
+enum class AppState {
+    IDLE,
+    FOCUS
+};
+
+class StateManager {
+public:
+    StateManager() : state_(AppState::IDLE) {}
+    void start_focus_session(const std::string& task_id);
+    void end_focus_session();
+    AppState get_current_state() const;
+    std::string current_task() const;
+private:
+    AppState state_;
+    std::string task_id_;
+};

--- a/firmware/tests/minigtest.h
+++ b/firmware/tests/minigtest.h
@@ -1,0 +1,64 @@
+#pragma once
+#include <functional>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace minigtest {
+struct Test {
+    std::string name;
+    std::function<void()> func;
+};
+
+inline std::vector<Test>& registry() {
+    static std::vector<Test> tests;
+    return tests;
+}
+
+struct Registrar {
+    Registrar(const std::string& name, std::function<void()> func) {
+        registry().push_back({name, std::move(func)});
+    }
+};
+
+inline int RunAllTests() {
+    int failures = 0;
+    for (const auto& t : registry()) {
+        try {
+            t.func();
+            std::cout << "[  OK  ] " << t.name << std::endl;
+        } catch (const std::exception& e) {
+            ++failures;
+            std::cout << "[ FAIL ] " << t.name << " - " << e.what() << std::endl;
+        } catch (...) {
+            ++failures;
+            std::cout << "[ FAIL ] " << t.name << std::endl;
+        }
+    }
+    std::cout << registry().size() - failures << " tests passed, "
+              << failures << " failed." << std::endl;
+    return failures;
+}
+} // namespace minigtest
+
+#define TEST(suite, name) \
+    void suite##_##name(); \
+    static minigtest::Registrar registrar_##suite##_##name(#suite "." #name, suite##_##name); \
+    void suite##_##name()
+
+#define EXPECT_EQ(expected, actual) \
+    do { \
+        if (!((expected) == (actual))) { \
+            std::cerr << __FILE__ << ":" << __LINE__ << " Expected equality" << std::endl; \
+        } \
+    } while (0)
+
+#define ASSERT_EQ(expected, actual) \
+    do { \
+        if (!((expected) == (actual))) { \
+            std::cerr << __FILE__ << ":" << __LINE__ << " Expected equality" << std::endl; \
+            throw std::runtime_error("ASSERT_EQ failed"); \
+        } \
+    } while (0)
+
+inline int RUN_ALL_TESTS() { return minigtest::RunAllTests(); }

--- a/firmware/tests/run_tests.ps1
+++ b/firmware/tests/run_tests.ps1
@@ -1,0 +1,8 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$BuildDir = Join-Path $ScriptDir "build"
+
+cmake -S $ScriptDir -B $BuildDir
+cmake --build $BuildDir
+& (Join-Path $BuildDir "firmware_tests")

--- a/firmware/tests/run_tests.sh
+++ b/firmware/tests/run_tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="$SCRIPT_DIR/build"
+
+cmake -S "$SCRIPT_DIR" -B "$BUILD_DIR"
+cmake --build "$BUILD_DIR"
+"$BUILD_DIR/firmware_tests"

--- a/firmware/tests/test_main.cpp
+++ b/firmware/tests/test_main.cpp
@@ -1,0 +1,5 @@
+#include "minigtest.h"
+
+int main() {
+    return RUN_ALL_TESTS();
+}

--- a/firmware/tests/test_powerhal.cpp
+++ b/firmware/tests/test_powerhal.cpp
@@ -1,0 +1,14 @@
+#include "minigtest.h"
+#include "PowerHAL.h"
+
+TEST(PowerHALTest, SetsHighPerformanceProfile) {
+    PowerHAL hal;
+    hal.set_cpu_frequency(240);
+    EXPECT_EQ(PowerProfile::HIGH_PERFORMANCE, hal.get_current_profile());
+}
+
+TEST(PowerHALTest, SetsNormalProfile) {
+    PowerHAL hal;
+    hal.set_cpu_frequency(80);
+    EXPECT_EQ(PowerProfile::NORMAL, hal.get_current_profile());
+}

--- a/firmware/tests/test_statemanager.cpp
+++ b/firmware/tests/test_statemanager.cpp
@@ -1,0 +1,13 @@
+#include "minigtest.h"
+#include "StateManager.h"
+
+TEST(StateManagerTest, StartsAndEndsFocusSession) {
+    StateManager mgr;
+    mgr.start_focus_session("task1");
+    EXPECT_EQ(AppState::FOCUS, mgr.get_current_state());
+    EXPECT_EQ(std::string("task1"), mgr.current_task());
+
+    mgr.end_focus_session();
+    EXPECT_EQ(AppState::IDLE, mgr.get_current_state());
+    EXPECT_EQ(std::string(""), mgr.current_task());
+}


### PR DESCRIPTION
## Summary
- Add AGENTS.md with instructions for running firmware unit tests
- Implement minimal C++ test harness and sample tests for PowerHAL and StateManager
- Provide cross-platform scripts to build and execute tests

## Testing
- `./firmware/tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ac4a047110832180e97a4468fdbe0c