### PR TITLE
chore: add components directory for build script

### DIFF
--- a/firmware/components/.gitkeep
+++ b/firmware/components/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for components directory


### PR DESCRIPTION
## Summary
- add placeholder components directory for build script validation

## Testing
- `pwsh firmware/build_scripts/test_build_syntax.ps1` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4b9c97008321b21993b86f9f9b50