### PR TITLE
Ensure IDF_PATH is set before running quality checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ SmartWatchProject/
 - **Arduino IDE** 2.0+ or **ESP-IDF** 5.0+
 - **Git** for version control
 - **PowerShell** (Windows) for quality automation
+- **IDF_PATH** environment variable set to your ESP-IDF installation (required for quality checks)
 - ESP32-S3 development board with touch LCD
 
 ### Hardware Setup
@@ -123,6 +124,8 @@ Multiple development environments supported:
 ### Quality Automation
 
 Comprehensive quality system with automated validation:
+
+> **Note:** Ensure the `IDF_PATH` environment variable points to your ESP-IDF installation before running quality checks.
 
 ```powershell
 # Deploy quality gates

--- a/firmware/quality_gates/run_quality_checks.ps1
+++ b/firmware/quality_gates/run_quality_checks.ps1
@@ -131,7 +131,7 @@ function Test-BuildQuality {
         Push-Location $FirmwarePath
         
         # Activate ESP-IDF environment
-        $env:IDF_PATH = "C:\esp\esp-idf"
+        if (-not $env:IDF_PATH) { throw "IDF_PATH not set" }
         
         # Run build and capture output
         $buildOutput = & idf.py build 2>&1


### PR DESCRIPTION
## Summary
- verify `IDF_PATH` is defined before running firmware build quality gate
- document `IDF_PATH` requirement in project build instructions

## Testing
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/validate-documents.ps1 -DocumentPath README.md` *(fails: pwsh command not found)*
- `sudo apt-get update` *(fails: repository InRelease not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4ba721f0832195fcff7973a1f7e2